### PR TITLE
Add pop-up menu to translate a translation string into another language

### DIFF
--- a/src/main/java/de/marhali/easyi18n/model/action/Translate.java
+++ b/src/main/java/de/marhali/easyi18n/model/action/Translate.java
@@ -1,0 +1,67 @@
+package de.marhali.easyi18n.model.action;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.project.Project;
+import de.marhali.easyi18n.util.NotificationHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Represents a translation into another language
+ * @author DatzAtWork
+ */
+public class Translate {
+
+    private static final String GLOSBE_URI = "https://translator-api.glosbe.com/translateByLangWithScoreXXXXX?sourceLang=%s&targetLang=%s";
+
+    private final @NotNull Project project;
+    private final @NotNull String textToTranslate;
+    private final @NotNull String targetLocale;
+    private final @NotNull String sourceLocale;
+
+    private final CompletableFuture<HttpResponse<String>> responseFuture;
+
+    public Translate(@NotNull Project project, String targetLocale, String sourceLocale, String textToTranslate) {
+        this.project = project;
+        this.sourceLocale = sourceLocale;
+        this.textToTranslate = textToTranslate;
+        this.targetLocale = targetLocale;
+
+        responseFuture = sendRequest(targetLocale, sourceLocale, textToTranslate);
+    }
+
+    private CompletableFuture<HttpResponse<String>> sendRequest(String targetLocale, String sourceLocale, String textToTranslate) {
+        final HttpClient client = HttpClient.newHttpClient();
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(java.net.URI.create(String.format(GLOSBE_URI, sourceLocale, targetLocale)))
+                .POST(HttpRequest.BodyPublishers.ofString(textToTranslate))
+                .build();
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply(Function.identity());
+    }
+
+    public Optional<String> getTranslation() {
+        final HttpResponse<String> response = this.responseFuture.join();
+        if(response.statusCode()==200) {
+            final JsonElement resultJson = JsonParser.parseString(response.body());
+            return Optional.of(((JsonObject) resultJson).get("translation").getAsString());
+        }
+        NotificationHelper.createTranslatorServiceErrorNotification(project, response.statusCode(), response.body());
+        return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        return "Translate{" +
+                "textToTranslate=" + textToTranslate +
+                ", targetLocale=" + targetLocale +
+                ", sourceLocale=" + sourceLocale + '}';
+    }
+}

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
@@ -32,4 +32,5 @@ public interface ProjectSettings {
 
     // Experimental Configuration
     boolean isAlwaysFold();
+    boolean isTranslatorServiceEnabled();
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
@@ -63,6 +63,7 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
                 .addVerticalGap(24)
                 .addComponent(new TitledSeparator(bundle.getString("settings.experimental.title")))
                 .addComponent(constructAlwaysFoldField())
+                .addComponent(constructTranslatorServiceEnabledField())
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -210,6 +211,12 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
         alwaysFold = new JBCheckBox(bundle.getString("settings.experimental.always-fold.title"));
         alwaysFold.setToolTipText(bundle.getString("settings.experimental.always-fold.tooltip"));
         return alwaysFold;
+    }
+
+    private JComponent constructTranslatorServiceEnabledField() {
+        translatorServiceEnabled = new JBCheckBox(bundle.getString("settings.experimental.translator.title"));
+        translatorServiceEnabled.setToolTipText(bundle.getString("settings.experimental.translator.tooltip"));
+        return translatorServiceEnabled;
     }
 
     private ItemListener handleParserChange() {

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
@@ -38,6 +38,7 @@ public class ProjectSettingsComponentState {
 
     // Experimental configuration
     protected JCheckBox alwaysFold;
+    protected JCheckBox translatorServiceEnabled;
 
     protected ProjectSettingsState getState() {
         // Every field needs to provide its state
@@ -61,6 +62,7 @@ public class ProjectSettingsComponentState {
         state.setAssistance(assistance.isSelected());
 
         state.setAlwaysFold(alwaysFold.isSelected());
+        state.setTranslatorServiceEnabled(translatorServiceEnabled.isSelected());
 
         return state;
     }
@@ -85,5 +87,6 @@ public class ProjectSettingsComponentState {
         assistance.setSelected(state.isAssistance());
 
         alwaysFold.setSelected(state.isAlwaysFold());
+        translatorServiceEnabled.setSelected(state.isTranslatorServiceEnabled());
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
@@ -37,6 +37,8 @@ public class ProjectSettingsState implements ProjectSettings {
     // Experimental configuration
     private Boolean alwaysFold;
 
+    private Boolean translatorServiceEnabled;
+
     public ProjectSettingsState() {}
 
     @Override
@@ -110,6 +112,11 @@ public class ProjectSettingsState implements ProjectSettings {
         return alwaysFold != null ? alwaysFold : defaults.isAlwaysFold();
     }
 
+    @Override
+    public boolean isTranslatorServiceEnabled() {
+        return translatorServiceEnabled != null ? translatorServiceEnabled : defaults.isTranslatorServiceEnabled();
+    }
+
     public void setLocalesDirectory(String localesDirectory) {
         this.localesDirectory = localesDirectory;
     }
@@ -164,5 +171,9 @@ public class ProjectSettingsState implements ProjectSettings {
 
     public void setAlwaysFold(Boolean alwaysFold) {
         this.alwaysFold = alwaysFold;
+    }
+
+    public void setTranslatorServiceEnabled(Boolean translatorServiceEnabled) {
+        this.translatorServiceEnabled = translatorServiceEnabled;
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
@@ -81,4 +81,7 @@ public class DefaultPreset implements ProjectSettings {
     public boolean isAlwaysFold() {
         return false;
     }
+
+    @Override
+    public boolean isTranslatorServiceEnabled() { return false; }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
@@ -81,4 +81,7 @@ public class ReactI18NextPreset implements ProjectSettings {
     public boolean isAlwaysFold() {
         return false;
     }
+
+    @Override
+    public boolean isTranslatorServiceEnabled() { return false; }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
@@ -80,4 +80,7 @@ public class VueI18nPreset implements ProjectSettings {
     public boolean isAlwaysFold() {
         return false;
     }
+
+    @Override
+    public boolean isTranslatorServiceEnabled() { return false; }
 }

--- a/src/main/java/de/marhali/easyi18n/util/NotificationHelper.java
+++ b/src/main/java/de/marhali/easyi18n/util/NotificationHelper.java
@@ -39,4 +39,14 @@ public class NotificationHelper {
 
         Notifications.Bus.notify(notification, project);
     }
+
+    public static void createTranslatorServiceErrorNotification(Project project, int statusCode, String response) {
+        final ResourceBundle bundle = ResourceBundle.getBundle("messages");
+
+        final String message = String.format("%s%nStatus %d: %s", bundle.getString("error.translator-error"), statusCode, response);
+        final Notification notification = new Notification("Easy I18n Notification Group", "Easy I18n",
+                message, NotificationType.ERROR);
+
+        Notifications.Bus.notify(notification, project);
+    }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -10,6 +10,7 @@ action.toggle-missing=Toggle missing translations
 action.reload=Reload From Disk
 action.settings=Settings
 action.search=Search...
+action.translate=Translate from {0}
 action.delete=Delete
 action.extract=Extract translation
 translation.key=Key
@@ -56,9 +57,12 @@ settings.editor.assistance.tooltip=Activates editor support to reference, auto-c
 settings.experimental.title=Experimental Configuration
 settings.experimental.always-fold.title=Always fold translation keys
 settings.experimental.always-fold.tooltip=Forces the editor to always display the value behind a translation key. The value cannot be unfolded when this function is active.
+settings.experimental.translator.title=Show translate pop-up menu for translations with https://glosbe.com/
+settings.experimental.translator.tooltip=Adds pop-ups to the input fields for translating the string into the 'Preview locale'
 error.io=An error occurred while processing translation files. \n\
   Config: {0} => {1} ({2}) \n\
   Path: {3} \n\
   Please check examples at https://github.com/marhali/easy-i18n before reporting an issue!
 error.submit=Open Issue
+error.translator-error=Error on translating a string.
 warning.missing-config=Configure your local project structure


### PR DESCRIPTION
I extended the plugin to use a free translator service to suggest translations.

right click->pop-up menu on a translation string

Conditions which must apply:
- feature enabled id settings
- translation in default locale must exist