### PR TITLE
Add support for path macros

### DIFF
--- a/src/main/java/de/marhali/easyi18n/io/IOHandler.java
+++ b/src/main/java/de/marhali/easyi18n/io/IOHandler.java
@@ -1,6 +1,7 @@
 package de.marhali.easyi18n.io;
 
 import com.intellij.codeInsight.actions.ReformatCodeProcessor;
+import com.intellij.openapi.components.PathMacroManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -57,7 +58,8 @@ public class IOHandler {
      * @throws IOException Could not read translation data
      */
     public @NotNull TranslationData read() throws IOException {
-        String localesPath = this.settings.getLocalesDirectory();
+        String localesPath = PathMacroManager.getInstance(project)
+                .expandPath(this.settings.getLocalesDirectory());
 
         if(localesPath == null || localesPath.isEmpty()) {
             throw new EmptyLocalesDirException("Locales path must not be empty");


### PR DESCRIPTION
This PR adds support for [IntelliJ's Path Variables/Macros](https://www.jetbrains.com/help/idea/absolute-path-variables.html) to the `Locales directory` setting.

In a nutshell, you can now replace the hardcoded path to the project with `$PROJECT_DIR$`.

**Note:** clicking the `browse` button in the property field doesn't open the folder specified, but rather the one you last selected in any setting.
Please check if this is acceptable.

fixes #189

<details>
<summary>Personal Note (unrelated to PR)</summary>
<br>
Thank you so much for your work on this project, it's a true blessing and a huge time saver :heart:<br>
Also a huge thanks for the quick updating to new IntelliJ Versions, as someone who is on EAP per default, the fast updates are really helpful :)
</details>