### PR TITLE
feat(Localize Selected): add LocalizeItAction for localizing selected…

### DIFF
--- a/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
+++ b/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
@@ -1,0 +1,43 @@
+package de.marhali.easyi18n.action;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import de.marhali.easyi18n.dialog.AddDialog;
+import de.marhali.easyi18n.model.KeyPath;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The LocalizeItAction class represents an IntelliJ IDEA action that localizes selected text.
+ *
+ * <p>When this action is performed, it retrieves the selected text from the editor, checks if it is not empty,
+ * and then displays a dialog to add the selected text as a localized string key to the project.
+ *
+ * <p>If the selected text is empty or the project is null, the action does nothing.
+ *
+ * <p>This class extends the AnAction class provided by IntelliJ IDEA.
+ */
+class LocalizeItAction extends AnAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+        DataContext dataContext = anActionEvent.getDataContext();
+        Editor editor = CommonDataKeys.EDITOR.getData(dataContext);
+        if (editor == null)
+            return;
+        String text = editor.getSelectionModel().getSelectedText();
+        if (text == null || text.isEmpty())
+            return;
+
+        Project project = anActionEvent.getProject();
+        if (project == null) {
+            throw new RuntimeException("Project is null!");
+        }
+
+        AddDialog dialog = new AddDialog(project, new KeyPath(text), text);
+        dialog.showAndHandle();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,13 @@
         >
             <add-to-group group-id="NewGroup"/>
         </action>
+        <action id="de.marhali.easyi18n.action.LocalizeItAction"
+                class="de.marhali.easyi18n.action.LocalizeItAction"
+                text="Localize It"
+                description="Apply localization to the selected string"
+                icon="/icons/translate13.svg">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </action>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
### Feature: Localize Selected Text

### Body:
Implement a new feature for the IntelliJ IDEA plugin named `LocalizeItAction`. 
The main objective of `Localize Action` is to localize the selected text within the editor without having to open the plugin to add a new one. The action flow should 

follow:
1. User Selects a Text (String Value).
2. User Invokes the menu , and Select the ` Localize-it` option.
3. If valid, showcase a dialog to add the selected text as a localized string key to the project.
4. Then user can update the keys and translation

Should the selected text be empty or the project null, the action will be dismissed and do nothing.

The `LocalizeItAction` class extends the IntelliJ IDEA's `AnAction` class

<img width="637" alt="Screenshot 2023-12-09 at 15 08 23" src="https://github.com/marhali/easy-i18n/assets/43365113/6a7682f0-6cdd-4cdf-a093-7fa21b562c2b">
<img width="637" alt="Screenshot 2023-12-09 at 15 09 27" src="https://github.com/marhali/easy-i18n/assets/43365113/5804f88f-8ddd-40fc-aebc-693602b6d18d">
<img width="1434" alt="Screenshot 2023-12-09 at 15 09 53" src="https://github.com/marhali/easy-i18n/assets/43365113/20d0b0cf-86e4-401e-8dc8-55cd139595c1">