### PR TITLE
Feature/Automated Key Naming Convention Suggestion for Localize-It Action

### DIFF
--- a/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
+++ b/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
@@ -83,21 +83,8 @@ class LocalizeItAction extends AnAction {
         return flavorTemplate + "(\"" + key + "\")";
     }
 
-    private String convertKeyToNamingCase(String key,Project project) {
-        String newKey = key.toLowerCase();
-        newKey = newKey.replaceAll("\\s+", "_");
-
-        NamingConvention namingConvention = ProjectSettingsService.get(project).getState().getCaseFormat();
-        return (namingConvention == NamingConvention.CAMEL_CASE) ? convertKeyToCamelCase(newKey) : convertKeyToSnakeCase(newKey);
+    private String convertKeyToNamingCase(String key, Project project) {
+        return NamingConvention.convertKeyToConvention(key, ProjectSettingsService.get(project).getState().getCaseFormat());
     }
 
-    private String convertKeyToCamelCase(String key) {
-
-
-        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key);
-    }
-
-    private String convertKeyToSnakeCase(String key) {
-        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_UNDERSCORE, key);
-    }
 }

--- a/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
+++ b/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
@@ -1,5 +1,6 @@
 package de.marhali.easyi18n.action;
 
+import com.google.common.base.CaseFormat;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -47,7 +48,7 @@ class LocalizeItAction extends AnAction {
             throw new RuntimeException("Project is null!");
         }
 
-        AddDialog dialog = new AddDialog(project, new KeyPath(text), text, (key) -> replaceSelectedText(project, editor, key));
+        AddDialog dialog = new AddDialog(project, new KeyPath(convertKeyToNamingCase(text, true)), text, (key) -> replaceSelectedText(project, editor, key));
         dialog.showAndHandle();
     }
 
@@ -55,8 +56,8 @@ class LocalizeItAction extends AnAction {
      * Replaces the selected text in the editor with a new text generated from the provided key.
      *
      * @param project the project where the editor belongs
-     * @param editor the editor where the text is selected
-     * @param key the key used to generate the replacement text
+     * @param editor  the editor where the text is selected
+     * @param key     the key used to generate the replacement text
      */
     private void replaceSelectedText(Project project, @NotNull Editor editor, @NotNull String key) {
         int selectionStart = editor.getSelectionModel().getSelectionStart();
@@ -71,13 +72,28 @@ class LocalizeItAction extends AnAction {
      * Builds a replacement string based on the provided flavor template, key, and document util.
      *
      * @param flavorTemplate the flavor template string
-     * @param key the key used to generate the replacement text
-     * @param documentUtil the document util object used to determine the document type
+     * @param key            the key used to generate the replacement text
+     * @param documentUtil   the document util object used to determine the document type
      * @return the built replacement string
      */
     private String buildReplacement(String flavorTemplate, String key, DocumentUtil documentUtil) {
         if (documentUtil.isVue() || documentUtil.isJsOrTs()) return flavorTemplate + "('" + key + "')";
 
         return flavorTemplate + "(\"" + key + "\")";
+    }
+
+    private String convertKeyToNamingCase(String key, boolean camelCase) {
+        String newKey = key.toLowerCase();
+        return camelCase ? convertKeyToCamelCase(newKey) : convertKeyToSnakeCase(newKey);
+    }
+
+    private String convertKeyToCamelCase(String key) {
+
+
+        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key);
+    }
+
+    private String convertKeyToSnakeCase(String key) {
+        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_UNDERSCORE, key);
     }
 }

--- a/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
+++ b/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
@@ -1,6 +1,5 @@
 package de.marhali.easyi18n.action;
 
-import com.google.common.base.CaseFormat;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -11,7 +10,7 @@ import com.intellij.openapi.project.Project;
 
 import de.marhali.easyi18n.dialog.AddDialog;
 import de.marhali.easyi18n.model.KeyPath;
-import de.marhali.easyi18n.settings.NamingConvention;
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettingsService;
 import de.marhali.easyi18n.util.DocumentUtil;
 
@@ -79,10 +78,16 @@ class LocalizeItAction extends AnAction {
      */
     private String buildReplacement(String flavorTemplate, String key, DocumentUtil documentUtil) {
         if (documentUtil.isVue() || documentUtil.isJsOrTs()) return flavorTemplate + "('" + key + "')";
-
         return flavorTemplate + "(\"" + key + "\")";
     }
 
+    /**
+     * Converts a given key to the specified naming convention.
+     *
+     * @param key the key to convert
+     * @param project the project where the key is being converted
+     * @return the converted key
+     */
     private String convertKeyToNamingCase(String key, Project project) {
         return NamingConvention.convertKeyToConvention(key, ProjectSettingsService.get(project).getState().getCaseFormat());
     }

--- a/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
+++ b/src/main/java/de/marhali/easyi18n/action/LocalizeItAction.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project;
 
 import de.marhali.easyi18n.dialog.AddDialog;
 import de.marhali.easyi18n.model.KeyPath;
+import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettingsService;
 import de.marhali.easyi18n.util.DocumentUtil;
 
@@ -48,7 +49,7 @@ class LocalizeItAction extends AnAction {
             throw new RuntimeException("Project is null!");
         }
 
-        AddDialog dialog = new AddDialog(project, new KeyPath(convertKeyToNamingCase(text, true)), text, (key) -> replaceSelectedText(project, editor, key));
+        AddDialog dialog = new AddDialog(project, new KeyPath(convertKeyToNamingCase(text, project)), text, (key) -> replaceSelectedText(project, editor, key));
         dialog.showAndHandle();
     }
 
@@ -82,9 +83,12 @@ class LocalizeItAction extends AnAction {
         return flavorTemplate + "(\"" + key + "\")";
     }
 
-    private String convertKeyToNamingCase(String key, boolean camelCase) {
+    private String convertKeyToNamingCase(String key,Project project) {
         String newKey = key.toLowerCase();
-        return camelCase ? convertKeyToCamelCase(newKey) : convertKeyToSnakeCase(newKey);
+        newKey = newKey.replaceAll("\\s+", "_");
+
+        NamingConvention namingConvention = ProjectSettingsService.get(project).getState().getCaseFormat();
+        return (namingConvention == NamingConvention.CAMEL_CASE) ? convertKeyToCamelCase(newKey) : convertKeyToSnakeCase(newKey);
     }
 
     private String convertKeyToCamelCase(String key) {

--- a/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
+++ b/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
@@ -1,0 +1,18 @@
+package de.marhali.easyi18n.settings;
+
+import com.google.common.base.CaseFormat;
+
+public enum NamingConvention {
+    SNAKE_CASE("Snake"),
+    CAMEL_CASE("Camel"),;
+    private final String name;
+
+    private NamingConvention(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return super.name().toLowerCase();
+    }
+}

--- a/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
+++ b/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
@@ -5,12 +5,10 @@ import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 
 public enum NamingConvention {
-    SNAKE_CASE("Snake Case"),
-
     CAMEL_CASE("Camel Case"),
-
     CAMEL_CASE_UPPERCASE("Camel Case Uppercase"),
-    ;
+    SNAKE_CASE("Snake Case"),
+    SNAKE_CASE_UPPERCASE("Snake Case Uppercase");
 
     private final String name;
 
@@ -36,5 +34,29 @@ public enum NamingConvention {
         return Arrays.stream(NamingConvention.values())
                 .map(NamingConvention::getName)
                 .toArray(String[]::new);
+    }
+
+    static public String convertKeyToConvention(String key, NamingConvention convention) {
+        String newKey = key.toLowerCase();
+        newKey = newKey.replaceAll("\\s+", "_");
+        return switch (convention) {
+            case SNAKE_CASE:
+                yield formatToSnakeCase(newKey, false);
+            case SNAKE_CASE_UPPERCASE:
+                yield formatToSnakeCase(newKey, true);
+            case CAMEL_CASE:
+                yield formatToCamelCase(newKey, false);
+            case CAMEL_CASE_UPPERCASE:
+                yield formatToCamelCase(newKey, true);
+
+        };
+    }
+
+    static private String formatToCamelCase(String key, boolean capitalized) {
+        return CaseFormat.LOWER_UNDERSCORE.to(capitalized ? CaseFormat.UPPER_CAMEL : CaseFormat.LOWER_CAMEL, key);
+    }
+
+    static private String formatToSnakeCase(String key, boolean capitalized) {
+        return CaseFormat.LOWER_UNDERSCORE.to(capitalized ? CaseFormat.UPPER_UNDERSCORE : CaseFormat.LOWER_UNDERSCORE, key);
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
+++ b/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
@@ -2,21 +2,39 @@ package de.marhali.easyi18n.settings;
 
 import com.google.common.base.CaseFormat;
 
+import java.util.Arrays;
+
 public enum NamingConvention {
-    SNAKE_CASE("Snake"),
-    CAMEL_CASE("Camel"),;
+    SNAKE_CASE("Snake Case"),
+
+    CAMEL_CASE("Camel Case"),
+
+    CAMEL_CASE_UPPERCASE("Camel Case Uppercase"),
+    ;
+
     private final String name;
 
     private NamingConvention(String name) {
         this.name = name;
     }
 
+    public String getName() {
+        return this.name;
+    }
+
     @Override
     public String toString() {
         return super.name().toLowerCase();
     }
+
     static public NamingConvention fromSelector(String name) {
-        String formated = name.replace(" ","_");
+        String formated = name.replace(" ", "_");
         return valueOf(formated.toUpperCase());
+    }
+
+    static public String[] getEnumNames() {
+        return Arrays.stream(NamingConvention.values())
+                .map(NamingConvention::getName)
+                .toArray(String[]::new);
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
+++ b/src/main/java/de/marhali/easyi18n/settings/NamingConvention.java
@@ -15,4 +15,8 @@ public enum NamingConvention {
     public String toString() {
         return super.name().toLowerCase();
     }
+    static public NamingConvention fromSelector(String name) {
+        String formated = name.replace(" ","_");
+        return valueOf(formated.toUpperCase());
+    }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
@@ -1,9 +1,9 @@
 package de.marhali.easyi18n.settings;
 
-import com.google.common.base.CaseFormat;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
 
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
@@ -9,31 +9,55 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * API to access the project-specific configuration for this plugin.
+ *
  * @author marhaliu
  */
 public interface ProjectSettings {
     // Resource Configuration
-    @Nullable String getLocalesDirectory();
-    @NotNull FolderStrategyType getFolderStrategy();
-    @NotNull ParserStrategyType getParserStrategy();
-    @NotNull String getFilePattern();
+    @Nullable
+    String getLocalesDirectory();
+
+    @NotNull
+    FolderStrategyType getFolderStrategy();
+
+    @NotNull
+    ParserStrategyType getParserStrategy();
+
+    @NotNull
+    String getFilePattern();
 
     boolean isIncludeSubDirs();
+
     boolean isSorting();
 
     // Editor Configuration
-    @Nullable String getNamespaceDelimiter();
-    @NotNull String getSectionDelimiter();
-    @Nullable String getContextDelimiter();
-    @Nullable String getPluralDelimiter();
-    @Nullable String getDefaultNamespace();
-    @NotNull String getPreviewLocale();
+    @Nullable
+    String getNamespaceDelimiter();
+
+    @NotNull
+    String getSectionDelimiter();
+
+    @Nullable
+    String getContextDelimiter();
+
+    @Nullable
+    String getPluralDelimiter();
+
+    @Nullable
+    String getDefaultNamespace();
+
+    @NotNull
+    String getPreviewLocale();
 
     boolean isNestedKeys();
+
     boolean isAssistance();
 
     // Experimental Configuration
     boolean isAlwaysFold();
+
     String getFlavorTemplate();
-    @NotNull NamingConvention getCaseFormat();
+
+    @NotNull
+    NamingConvention getCaseFormat();
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
@@ -1,5 +1,6 @@
 package de.marhali.easyi18n.settings;
 
+import com.google.common.base.CaseFormat;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
 
@@ -34,4 +35,5 @@ public interface ProjectSettings {
     // Experimental Configuration
     boolean isAlwaysFold();
     String getFlavorTemplate();
+    @NotNull NamingConvention getCaseFormat();
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
@@ -1,6 +1,5 @@
 package de.marhali.easyi18n.settings;
 
-import com.google.common.base.CaseFormat;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.project.Project;
@@ -14,6 +13,7 @@ import com.intellij.util.ui.FormBuilder;
 
 import de.marhali.easyi18n.io.parser.ArrayMapper;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import de.marhali.easyi18n.settings.presets.Preset;
 
 import javax.swing.*;
@@ -233,7 +233,7 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
     private JComponent constructKeyCaseFormater() {
         KeyCaseFormater = new ComboBox<>(NamingConvention.getEnumNames());
         KeyCaseFormater.setToolTipText(bundle.getString("settings.experimental.key-naming-format.tooltip"));
-        KeyCaseFormater.setMinimumAndPreferredWidth(120);
+        KeyCaseFormater.setMinimumAndPreferredWidth(200);
         return KeyCaseFormater;
     }
 

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
@@ -231,12 +231,9 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
     }
 
     private JComponent constructKeyCaseFormater() {
-        KeyCaseFormater = new ComboBox<>(bundle.getString("settings.experimental.key-naming-format.items").split(ArrayMapper.SPLITERATOR_REGEX));
+        KeyCaseFormater = new ComboBox<>(NamingConvention.getEnumNames());
         KeyCaseFormater.setToolTipText(bundle.getString("settings.experimental.key-naming-format.tooltip"));
         KeyCaseFormater.setMinimumAndPreferredWidth(120);
-        KeyCaseFormater.addActionListener(e -> {
-
-        });
         return KeyCaseFormater;
     }
 

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
@@ -1,5 +1,6 @@
 package de.marhali.easyi18n.settings;
 
+import com.google.common.base.CaseFormat;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.project.Project;
@@ -26,6 +27,7 @@ import java.util.ResourceBundle;
 
 /**
  * Configuration panel with all possible options for this plugin.
+ *
  * @author marhali
  */
 public class ProjectSettingsComponent extends ProjectSettingsComponentState {
@@ -64,7 +66,9 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
                 .addVerticalGap(24)
                 .addComponent(new TitledSeparator(bundle.getString("settings.experimental.title")))
                 .addComponent(constructAlwaysFoldField())
+                .addVerticalGap(12)
                 .addLabeledComponent(bundle.getString("settings.experimental.flavor-template"), constructFlavorTemplate(), 1, false)
+                .addLabeledComponent(bundle.getString("settings.experimental.key-naming-format.title"), constructKeyCaseFormater(), 1, false)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -225,6 +229,17 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
         flavorTemplate.setToolTipText(bundle.getString("settings.experimental.flavor-template-tooltip"));
         return flavorTemplate;
     }
+
+    private JComponent constructKeyCaseFormater() {
+        KeyCaseFormater = new ComboBox<>(bundle.getString("settings.experimental.key-naming-format.items").split(ArrayMapper.SPLITERATOR_REGEX));
+        KeyCaseFormater.setToolTipText(bundle.getString("settings.experimental.key-naming-format.tooltip"));
+        KeyCaseFormater.setMinimumAndPreferredWidth(120);
+        KeyCaseFormater.addActionListener(e -> {
+
+        });
+        return KeyCaseFormater;
+    }
+
 
     private ItemListener handleParserChange() {
         return e -> {

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
@@ -1,5 +1,6 @@
 package de.marhali.easyi18n.settings;
 
+import com.google.common.base.CaseFormat;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 
@@ -11,6 +12,7 @@ import javax.swing.*;
 
 /**
  * Mandatory for state management for the project settings component.
+ *
  * @author marhali
  */
 public class ProjectSettingsComponentState {
@@ -41,6 +43,7 @@ public class ProjectSettingsComponentState {
     protected JCheckBox alwaysFold;
 
     protected JTextField flavorTemplate;
+    protected ComboBox<String> KeyCaseFormater;
 
     protected ProjectSettingsState getState() {
         // Every field needs to provide its state
@@ -67,6 +70,8 @@ public class ProjectSettingsComponentState {
         state.setAlwaysFold(alwaysFold.isSelected());
         state.setFlavorTemplate(flavorTemplate.getText());
 
+        state.setCaseFormat(NamingConvention.valueOf(KeyCaseFormater.getSelectedItem().toString().replace("Case", "").trim()));
+
         return state;
     }
 
@@ -92,5 +97,6 @@ public class ProjectSettingsComponentState {
 
         alwaysFold.setSelected(state.isAlwaysFold());
         flavorTemplate.setText(state.getFlavorTemplate());
+        KeyCaseFormater.setSelectedItem(state.getCaseFormat().name());
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
@@ -1,15 +1,14 @@
 package de.marhali.easyi18n.settings;
 
-import com.google.common.base.CaseFormat;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import de.marhali.easyi18n.settings.presets.Preset;
 
 import javax.swing.*;
-import java.util.Objects;
 
 /**
  * Mandatory for state management for the project settings component.
@@ -72,7 +71,7 @@ public class ProjectSettingsComponentState {
 
         state.setFlavorTemplate(flavorTemplate.getText());
 
-        state.setCaseFormat(NamingConvention.fromSelector(KeyCaseFormater.getSelectedItem().toString()));
+        state.setCaseFormat(NamingConvention.fromString(KeyCaseFormater.getSelectedItem().toString()));
 
         return state;
     }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
@@ -99,6 +99,7 @@ public class ProjectSettingsComponentState {
 
         alwaysFold.setSelected(state.isAlwaysFold());
         flavorTemplate.setText(state.getFlavorTemplate());
-        KeyCaseFormater.setSelectedItem(state.getCaseFormat().name());
+        KeyCaseFormater.setSelectedItem(state.getCaseFormat().getName());
     }
+
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
@@ -9,6 +9,7 @@ import de.marhali.easyi18n.io.folder.FolderStrategyType;
 import de.marhali.easyi18n.settings.presets.Preset;
 
 import javax.swing.*;
+import java.util.Objects;
 
 /**
  * Mandatory for state management for the project settings component.
@@ -68,9 +69,10 @@ public class ProjectSettingsComponentState {
         state.setAssistance(assistance.isSelected());
 
         state.setAlwaysFold(alwaysFold.isSelected());
+
         state.setFlavorTemplate(flavorTemplate.getText());
 
-        state.setCaseFormat(NamingConvention.valueOf(KeyCaseFormater.getSelectedItem().toString().replace("Case", "").trim()));
+        state.setCaseFormat(NamingConvention.fromSelector(KeyCaseFormater.getSelectedItem().toString()));
 
         return state;
     }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
@@ -95,6 +95,7 @@ public class ProjectSettingsState implements ProjectSettings {
 
         this.alwaysFold = defaults.isAlwaysFold();
         this.flavorTemplate = defaults.getFlavorTemplate();
+        this.caseFormat = defaults.getCaseFormat();
     }
 
     @Override

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
@@ -1,12 +1,12 @@
 package de.marhali.easyi18n.settings;
 
-import com.google.common.base.CaseFormat;
 import com.intellij.util.xmlb.annotations.Property;
 
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
 import de.marhali.easyi18n.settings.presets.DefaultPreset;
 
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
@@ -1,5 +1,6 @@
 package de.marhali.easyi18n.settings;
 
+import com.google.common.base.CaseFormat;
 import com.intellij.util.xmlb.annotations.Property;
 
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
@@ -13,32 +14,48 @@ import java.util.Objects;
 
 /**
  * Represents the project-specific configuration of this plugin.
+ *
  * @author marhali
  */
 public class ProjectSettingsState implements ProjectSettings {
 
     // Resource Configuration
-    @Property private String localesDirectory;
-    @Property private FolderStrategyType folderStrategy;
-    @Property private ParserStrategyType parserStrategy;
-    @Property private String filePattern;
+    @Property
+    private String localesDirectory;
+    @Property
+    private FolderStrategyType folderStrategy;
+    @Property
+    private ParserStrategyType parserStrategy;
+    @Property
+    private String filePattern;
 
-    @Property private Boolean includeSubDirs;
-    @Property private boolean sorting;
+    @Property
+    private Boolean includeSubDirs;
+    @Property
+    private boolean sorting;
 
     // Editor configuration
-    @Property private String namespaceDelimiter;
-    @Property private String sectionDelimiter;
-    @Property private String contextDelimiter;
-    @Property private String pluralDelimiter;
-    @Property private String defaultNamespace;
-    @Property private String previewLocale;
+    @Property
+    private String namespaceDelimiter;
+    @Property
+    private String sectionDelimiter;
+    @Property
+    private String contextDelimiter;
+    @Property
+    private String pluralDelimiter;
+    @Property
+    private String defaultNamespace;
+    @Property
+    private String previewLocale;
 
-    @Property private Boolean nestedKeys;
-    @Property private Boolean assistance;
+    @Property
+    private Boolean nestedKeys;
+    @Property
+    private Boolean assistance;
 
     // Experimental configuration
-    @Property private Boolean alwaysFold;
+    @Property
+    private Boolean alwaysFold;
 
     /**
      * The `flavorTemplate` specifies the format used for replacing strings with their i18n (internationalization) counterparts.
@@ -47,7 +64,10 @@ public class ProjectSettingsState implements ProjectSettings {
      * the specific framework or developers' preferences for handling i18n. The ability to dynamically change this template adds flexibility and customization
      * to cater to different i18n handling methods.
      */
-    @Property private String flavorTemplate;
+    @Property
+    private String flavorTemplate;
+    @Property
+    private NamingConvention caseFormat;
 
     public ProjectSettingsState() {
         this(new DefaultPreset());
@@ -158,6 +178,11 @@ public class ProjectSettingsState implements ProjectSettings {
         return this.flavorTemplate;
     }
 
+    @Override
+    public @NotNull NamingConvention getCaseFormat() {
+        return this.caseFormat;
+    }
+
     public void setLocalesDirectory(String localesDirectory) {
         this.localesDirectory = localesDirectory;
     }
@@ -218,9 +243,14 @@ public class ProjectSettingsState implements ProjectSettings {
         this.alwaysFold = alwaysFold;
     }
 
-    public void setFlavorTemplate(String flavorTemplate){
+    public void setFlavorTemplate(String flavorTemplate) {
         this.flavorTemplate = flavorTemplate;
     }
+
+    public void setCaseFormat(NamingConvention caseFormat) {
+        this.caseFormat = caseFormat;
+    }
+
 
     @Override
     public boolean equals(Object o) {
@@ -242,7 +272,8 @@ public class ProjectSettingsState implements ProjectSettings {
                 && Objects.equals(nestedKeys, that.nestedKeys)
                 && Objects.equals(assistance, that.assistance)
                 && Objects.equals(alwaysFold, that.alwaysFold)
-                && Objects.equals(flavorTemplate,that.flavorTemplate);
+                && Objects.equals(flavorTemplate, that.flavorTemplate)
+                && Objects.equals(caseFormat, that.caseFormat);
     }
 
     @Override
@@ -250,7 +281,7 @@ public class ProjectSettingsState implements ProjectSettings {
         return Objects.hash(
                 localesDirectory, folderStrategy, parserStrategy, filePattern, includeSubDirs,
                 sorting, namespaceDelimiter, sectionDelimiter, contextDelimiter, pluralDelimiter,
-                defaultNamespace, previewLocale, nestedKeys, assistance, alwaysFold,flavorTemplate
+                defaultNamespace, previewLocale, nestedKeys, assistance, alwaysFold, flavorTemplate, caseFormat
         );
     }
 
@@ -273,6 +304,7 @@ public class ProjectSettingsState implements ProjectSettings {
                 ", assistance=" + assistance +
                 ", alwaysFold=" + alwaysFold +
                 ", flavorTemplate=" + flavorTemplate +
+                ", caseFormat=" + caseFormat.toString() +
                 '}';
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
@@ -66,6 +66,7 @@ public class ProjectSettingsState implements ProjectSettings {
      */
     @Property
     private String flavorTemplate;
+
     @Property
     private NamingConvention caseFormat;
 

--- a/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
@@ -2,7 +2,6 @@ package de.marhali.easyi18n.settings.presets;
 
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
-import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
@@ -2,6 +2,7 @@ package de.marhali.easyi18n.settings.presets;
 
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
+import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 
 import org.jetbrains.annotations.NotNull;
@@ -90,5 +91,10 @@ public class DefaultPreset implements ProjectSettings {
     @Override
     public String getFlavorTemplate() {
         return "$i18n.t";
+    }
+
+    @Override
+    public @NotNull NamingConvention getCaseFormat() {
+        return NamingConvention.CAMEL_CASE;
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/NamingConvention.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/NamingConvention.java
@@ -1,14 +1,18 @@
-package de.marhali.easyi18n.settings;
+package de.marhali.easyi18n.settings.presets;
 
 import com.google.common.base.CaseFormat;
 
 import java.util.Arrays;
 
+/**
+ * Enum representing different naming conventions.
+ * Provides utility methods to convert keys to the specified convention.
+ */
 public enum NamingConvention {
     CAMEL_CASE("Camel Case"),
-    CAMEL_CASE_UPPERCASE("Camel Case Uppercase"),
+    CAMEL_CASE_UPPERCASE("Camel Case (Uppercase)"),
     SNAKE_CASE("Snake Case"),
-    SNAKE_CASE_UPPERCASE("Snake Case Uppercase");
+    SNAKE_CASE_UPPERCASE("Snake Case (Uppercase)");
 
     private final String name;
 
@@ -16,6 +20,11 @@ public enum NamingConvention {
         this.name = name;
     }
 
+    /**
+     * Retrieves the name of the current instance of the class.
+     *
+     * @return the name of the current instance
+     */
     public String getName() {
         return this.name;
     }
@@ -25,17 +34,38 @@ public enum NamingConvention {
         return super.name().toLowerCase();
     }
 
-    static public NamingConvention fromSelector(String name) {
-        String formated = name.replace(" ", "_");
-        return valueOf(formated.toUpperCase());
+    /**
+     * Converts a string representation of a naming convention to the corresponding NamingConvention enum value.
+     *
+     * @param name the string representation of the naming convention
+     * @return the corresponding NamingConvention enum value
+     */
+    static public NamingConvention fromString(String name) {
+        for (NamingConvention value : NamingConvention.values()) {
+            if (value.getName().equals(name))
+                return value;
+        }
+        return NamingConvention.CAMEL_CASE;
     }
 
+    /**
+     * Returns an array of strings representing the names of the enum values in the {@link NamingConvention} enum.
+     *
+     * @return an array of strings representing the enum names
+     */
     static public String[] getEnumNames() {
         return Arrays.stream(NamingConvention.values())
                 .map(NamingConvention::getName)
                 .toArray(String[]::new);
     }
 
+    /**
+     * Converts a given key to the specified naming convention.
+     *
+     * @param key        the key to convert
+     * @param convention the naming convention to convert the key to
+     * @return the converted key
+     */
     static public String convertKeyToConvention(String key, NamingConvention convention) {
         String newKey = key.toLowerCase();
         newKey = newKey.replaceAll("\\s+", "_");

--- a/src/main/java/de/marhali/easyi18n/settings/presets/NamingConvention.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/NamingConvention.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
  */
 public enum NamingConvention {
     CAMEL_CASE("Camel Case"),
-    CAMEL_CASE_UPPERCASE("Camel Case (Uppercase)"),
+    PASCAL_CASE("Pascal Case"),
     SNAKE_CASE("Snake Case"),
     SNAKE_CASE_UPPERCASE("Snake Case (Uppercase)");
 
@@ -76,7 +76,7 @@ public enum NamingConvention {
                 yield formatToSnakeCase(newKey, true);
             case CAMEL_CASE:
                 yield formatToCamelCase(newKey, false);
-            case CAMEL_CASE_UPPERCASE:
+            case PASCAL_CASE:
                 yield formatToCamelCase(newKey, true);
 
         };

--- a/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
@@ -1,9 +1,7 @@
 package de.marhali.easyi18n.settings.presets;
 
-import com.google.common.base.CaseFormat;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
-import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
@@ -1,7 +1,9 @@
 package de.marhali.easyi18n.settings.presets;
 
+import com.google.common.base.CaseFormat;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
+import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 
 import org.jetbrains.annotations.NotNull;
@@ -90,5 +92,9 @@ public class ReactI18NextPreset implements ProjectSettings {
     @Override
     public String getFlavorTemplate() {
         return "$i18n.t";
+    }
+    @Override
+    public @NotNull NamingConvention getCaseFormat() {
+        return NamingConvention.CAMEL_CASE;
     }
 }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
@@ -2,7 +2,6 @@ package de.marhali.easyi18n.settings.presets;
 
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
-import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
@@ -2,6 +2,7 @@ package de.marhali.easyi18n.settings.presets;
 
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
+import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -89,5 +90,10 @@ public class VueI18nPreset implements ProjectSettings {
     @Override
     public String getFlavorTemplate() {
         return "$i18n.t";
+    }
+
+    @Override
+    public @NotNull NamingConvention getCaseFormat() {
+        return NamingConvention.CAMEL_CASE;
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -64,7 +64,6 @@ settings.experimental.flavor-template =I18n flavor template
 settings.experimental.flavor-template-tooltip = Specify how to replace strings with i18n representation.
 settings.experimental.key-naming-format.title=Key format of extracted translation
 settings.experimental.key-naming-format.tooltip=Choose Naming Convention for the keys of extracted translation
-settings.experimental.key-naming-format.items=Camel Case;Snake Case
 
 error.io=An error occurred while processing translation files. \n\
   Config: {0} => {1} ({2}) \n\

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -62,6 +62,10 @@ settings.experimental.always-fold.title=Always fold translation keys
 settings.experimental.always-fold.tooltip=Forces the editor to always display the value behind a translation key. The value cannot be unfolded when this function is active.
 settings.experimental.flavor-template =I18n flavor template
 settings.experimental.flavor-template-tooltip = Specify how to replace strings with i18n representation.
+settings.experimental.key-naming-format.title=Key format of extracted translation
+settings.experimental.key-naming-format.tooltip=Choose Naming Convention for the keys of extracted translation
+settings.experimental.key-naming-format.items=Camel Case;Snake Case
+
 error.io=An error occurred while processing translation files. \n\
   Config: {0} => {1} ({2}) \n\
   Path: {3} \n\

--- a/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
+++ b/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
@@ -3,6 +3,7 @@ package de.marhali.easyi18n;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
 import de.marhali.easyi18n.model.KeyPath;
+import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 import de.marhali.easyi18n.util.KeyPathConverter;
 
@@ -171,6 +172,11 @@ public class KeyPathConverterTest {
             @Override
             public boolean isIncludeSubDirs() {
                 return false;
+            }
+
+            @Override
+            public @NotNull NamingConvention getCaseFormat() {
+                return NamingConvention.CAMEL_CASE;
             }
         });
     }

--- a/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
+++ b/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
@@ -3,7 +3,7 @@ package de.marhali.easyi18n;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
 import de.marhali.easyi18n.model.KeyPath;
-import de.marhali.easyi18n.settings.NamingConvention;
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 import de.marhali.easyi18n.util.KeyPathConverter;
 

--- a/src/test/java/de/marhali/easyi18n/e2e/EndToEndTestCase.java
+++ b/src/test/java/de/marhali/easyi18n/e2e/EndToEndTestCase.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 /**
  * End-to-end test case.
+ *
  * @author marhali
  */
 public abstract class EndToEndTestCase extends BasePlatformTestCase {
@@ -57,7 +58,8 @@ public abstract class EndToEndTestCase extends BasePlatformTestCase {
         out.setLocalesDirectory(tempPath.toString());
         ProjectSettingsService.get(getProject()).setState(out);
 
-        InstanceManager.get(getProject()).store().saveToPersistenceLayer(success -> {});
+        InstanceManager.get(getProject()).store().saveToPersistenceLayer(success -> {
+        });
 
         // Compare file structure and contents
         IOFileFilter fileFilter = TrueFileFilter.INSTANCE;
@@ -73,7 +75,7 @@ public abstract class EndToEndTestCase extends BasePlatformTestCase {
 
         assertEquals(originalFiles.length, outputFiles.length);
 
-        for(int i = 0; i < originalFiles.length; i++) {
+        for (int i = 0; i < originalFiles.length; i++) {
             File originalFile = originalFiles[i];
             File outputFile = outputFiles[i];
 

--- a/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
@@ -7,6 +7,7 @@ import de.marhali.easyi18n.io.parser.properties.PropertiesMapper;
 import de.marhali.easyi18n.io.parser.properties.SortableProperties;
 import de.marhali.easyi18n.model.TranslationData;
 import de.marhali.easyi18n.model.KeyPath;
+import de.marhali.easyi18n.settings.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 import de.marhali.easyi18n.util.KeyPathConverter;
 
@@ -19,6 +20,7 @@ import java.util.*;
 
 /**
  * Unit tests for {@link PropertiesMapper}.
+ *
  * @author marhali
  */
 public class PropertiesMapperTest extends AbstractMapperTest {
@@ -244,6 +246,11 @@ public class PropertiesMapperTest extends AbstractMapperTest {
             @Override
             public boolean isIncludeSubDirs() {
                 return false;
+            }
+
+            @Override
+            public @NotNull NamingConvention getCaseFormat() {
+                return NamingConvention.CAMEL_CASE;
             }
         });
     }

--- a/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
@@ -7,7 +7,7 @@ import de.marhali.easyi18n.io.parser.properties.PropertiesMapper;
 import de.marhali.easyi18n.io.parser.properties.SortableProperties;
 import de.marhali.easyi18n.model.TranslationData;
 import de.marhali.easyi18n.model.KeyPath;
-import de.marhali.easyi18n.settings.NamingConvention;
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import de.marhali.easyi18n.settings.ProjectSettings;
 import de.marhali.easyi18n.util.KeyPathConverter;
 

--- a/src/test/java/de/marhali/easyi18n/settings/NamingConventionTest.java
+++ b/src/test/java/de/marhali/easyi18n/settings/NamingConventionTest.java
@@ -1,0 +1,35 @@
+package de.marhali.easyi18n.settings;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import de.marhali.easyi18n.settings.presets.NamingConvention;
+
+import java.io.IOException;
+
+public class NamingConventionTest extends BasePlatformTestCase {
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testConvertToNamingConvention() throws IOException {
+        assertEquals("helloWorld", NamingConvention.convertKeyToConvention("Hello World", NamingConvention.CAMEL_CASE));
+        assertEquals("hello_world", NamingConvention.convertKeyToConvention("Hello World", NamingConvention.SNAKE_CASE));
+        assertEquals("HelloWorld", NamingConvention.convertKeyToConvention("Hello World", NamingConvention.PASCAL_CASE));
+        assertEquals("HELLO_WORLD", NamingConvention.convertKeyToConvention("Hello World", NamingConvention.SNAKE_CASE_UPPERCASE));
+    }
+
+    public void testGetEnumNames() throws Exception {
+        String[] expected = {"Camel Case", "Pascal Case", "Snake Case", "Snake Case (Uppercase)"};
+        String[] actual = NamingConvention.getEnumNames();
+        assertEquals(expected.length, actual.length);
+    }
+
+
+    public void testFromString() {
+        assertEquals(NamingConvention.CAMEL_CASE, NamingConvention.fromString("Camel Case"));
+        assertEquals(NamingConvention.PASCAL_CASE, NamingConvention.fromString("Pascal Case"));
+        assertEquals(NamingConvention.SNAKE_CASE, NamingConvention.fromString("Snake Case"));
+        assertEquals(NamingConvention.SNAKE_CASE_UPPERCASE, NamingConvention.fromString("Snake Case (Uppercase)"));
+        assertEquals(NamingConvention.CAMEL_CASE, NamingConvention.fromString("Invalid Input"));
+    }
+}

--- a/src/test/java/de/marhali/easyi18n/settings/ProjectSettingsServiceTest.java
+++ b/src/test/java/de/marhali/easyi18n/settings/ProjectSettingsServiceTest.java
@@ -4,6 +4,7 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 
 import de.marhali.easyi18n.settings.presets.DefaultPreset;
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 
 /**
  * Tests for the project settings service itself.

--- a/src/test/java/de/marhali/easyi18n/settings/ProjectSettingsServiceTest.java
+++ b/src/test/java/de/marhali/easyi18n/settings/ProjectSettingsServiceTest.java
@@ -7,6 +7,7 @@ import de.marhali.easyi18n.settings.presets.DefaultPreset;
 
 /**
  * Tests for the project settings service itself.
+ *
  * @author marhali
  */
 public class ProjectSettingsServiceTest extends BasePlatformTestCase {
@@ -34,5 +35,13 @@ public class ProjectSettingsServiceTest extends BasePlatformTestCase {
 
         ProjectSettingsState after = XmlSerializerUtil.createCopy(previous);
         assertEquals("mySinglePropTest", after.getLocalesDirectory());
+    }
+
+    public void testPersistenceFormatCase() {
+        ProjectSettingsState previous = new ProjectSettingsState();
+        assertEquals(previous.getCaseFormat(), NamingConvention.CAMEL_CASE);
+        previous.setCaseFormat(NamingConvention.SNAKE_CASE);
+        ProjectSettingsState after = XmlSerializerUtil.createCopy(previous);
+        assertEquals(after.getCaseFormat(), NamingConvention.SNAKE_CASE);
     }
 }

--- a/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
+++ b/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
@@ -1,5 +1,6 @@
 package de.marhali.easyi18n.settings;
 
+import com.google.common.base.CaseFormat;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 
@@ -8,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Settings preset to test the functionality of the settings service.
+ *
  * @author marhali
  */
 public class SettingsTestPreset implements ProjectSettings {
@@ -88,6 +90,11 @@ public class SettingsTestPreset implements ProjectSettings {
 
     @Override
     public String getFlavorTemplate() {
-        return "";
+        return "t";
+    }
+
+    @Override
+    public @NotNull NamingConvention getCaseFormat() {
+        return NamingConvention.CAMEL_CASE;
     }
 }

--- a/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
+++ b/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
@@ -1,9 +1,9 @@
 package de.marhali.easyi18n.settings;
 
-import com.google.common.base.CaseFormat;
 import de.marhali.easyi18n.io.folder.FolderStrategyType;
 import de.marhali.easyi18n.io.parser.ParserStrategyType;
 
+import de.marhali.easyi18n.settings.presets.NamingConvention;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 


### PR DESCRIPTION
### Pull Request Description
This pull request introduces an enhancement to the Localize-It Action, addressing the manual adjustment requirement for key naming conventions during string extraction. The implemented feature automates key naming convention suggestions, significantly improving user experience and code consistency.

- Fixes marhali/easy-i18n#398
___
#### Changes Implemented:

- **Automated Key Naming Convention Suggestions**: Integrated functionality to automatically suggest key naming conventions based on user preferences or project settings.

- **Support for CamelCase , PascalCase and Snake_case**: Initial implementation covers CamelCase and Snake_case naming conventions.

#### Future Considerations:

- Expansion of Supported Naming Conventions: Consider adding support for additional naming conventions based on user feedback and industry standards. This could include, kebab-case, etc.

### Next Steps:
- **Review and Merge**: Request code review  and merge the changes once approved.
___
## Show Case:

### Before
![image](https://github.com/marhali/easy-i18n/assets/43365113/57bce5ca-80da-4940-885f-436ad292c31b)

### After

![image](https://github.com/marhali/easy-i18n/assets/43365113/1aa563e9-2ea9-4882-b0b0-2d5690901ae6)
