### PR TITLE
support json for TranslationDialog

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -16,6 +16,10 @@ action.extract=Extract translation
 action.file=Open file
 translation.key=Key
 translation.locales=Locales
+translation.jsonInput=Json
+translation.processJson=UseJson
+translation.invalidJson=invalidJson
+translation.error=Error
 # Settings
 settings.hint.text=Project-specific configuration. For an easy start, you can use one of the existing presets.
 settings.hint.action=Fore more information, see the documentation


### PR DESCRIPTION
Thank you for developing easy-i18n, which has saved me a lot of time. However, I've found that adding a 'key' requires copying and pasting content for each language individually, which is somewhat painful. Since I used AI to generate JSON, I developed a function to parse JSON, hoping it can help more people.

![image](https://github.com/marhali/easy-i18n/assets/21982940/aa029f27-65bd-48b8-9c82-ec738cd05cf4)
