### PR TITLE
implement save as strings setting + tests

### DIFF
--- a/src/main/java/de/marhali/easyi18n/io/parser/json/JsonMapper.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/json/JsonMapper.java
@@ -42,7 +42,7 @@ public class JsonMapper {
         }
     }
 
-    public static void write(String locale, JsonObject json, TranslationNode node) {
+    public static void write(String locale, JsonObject json, TranslationNode node,boolean isSaveAsString) {
         for(Map.Entry<String, TranslationNode> entry : node.getChildren().entrySet()) {
             String key = entry.getKey();
             TranslationNode childNode = entry.getValue();
@@ -50,20 +50,24 @@ public class JsonMapper {
             if(!childNode.isLeaf()) {
                 // Nested node - run recursively
                 JsonObject childJson = new JsonObject();
-                write(locale, childJson, childNode);
+                write(locale, childJson, childNode, isSaveAsString);
                 if(childJson.size() > 0) {
                     json.add(key, childJson);
                 }
             } else {
                 TranslationValue translation = childNode.getValue();
                 String content = translation.get(locale);
+                // log content
 
                 if(content != null) {
                     if(JsonArrayMapper.isArray(content)) {
+                        System.out.print("array: " + content);
                         json.add(key, JsonArrayMapper.write(content));
-                    } else if(NumberUtils.isCreatable(content)) {
+                    } else if(!isSaveAsString && NumberUtils.isCreatable(content)) {
+                        System.out.println("number: " + content);
                         json.add(key, new JsonPrimitive(NumberUtils.createNumber(content)));
                     } else {
+                        System.out.println("else: " + content);
                         json.add(key, new JsonPrimitive(StringEscapeUtils.unescapeJava(content)));
                     }
                 }

--- a/src/main/java/de/marhali/easyi18n/io/parser/json/JsonParserStrategy.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/json/JsonParserStrategy.java
@@ -25,9 +25,10 @@ import java.util.Objects;
 public class JsonParserStrategy extends ParserStrategy {
 
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-
+    private final boolean isSaveAsStrings;
     public JsonParserStrategy(@NotNull ProjectSettings settings) {
         super(settings);
+        this.isSaveAsStrings = settings.isSaveAsStrings();
     }
 
     @Override
@@ -57,7 +58,7 @@ public class JsonParserStrategy extends ParserStrategy {
         TranslationNode targetNode = super.getTargetNode(data, file);
 
         JsonObject output = new JsonObject();
-        JsonMapper.write(file.getLocale(), output, Objects.requireNonNull(targetNode));
+        JsonMapper.write(file.getLocale(), output, Objects.requireNonNull(targetNode), isSaveAsStrings);
 
         return GSON.toJson(output);
     }

--- a/src/main/java/de/marhali/easyi18n/io/parser/json5/Json5Mapper.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/json5/Json5Mapper.java
@@ -40,7 +40,7 @@ public class Json5Mapper {
         }
     }
 
-    public static void write(String locale, Json5Object json, TranslationNode node) {
+    public static void write(String locale, Json5Object json, TranslationNode node, boolean isSaveAsStrings) {
         for(Map.Entry<String, TranslationNode> entry : node.getChildren().entrySet()) {
             String key = entry.getKey();
             TranslationNode childNode = entry.getValue();
@@ -48,7 +48,7 @@ public class Json5Mapper {
             if(!childNode.isLeaf()) {
                 // Nested node - run recursively
                 Json5Object childJson = new Json5Object();
-                write(locale, childJson, childNode);
+                write(locale, childJson, childNode, isSaveAsStrings);
                 if(childJson.size() > 0) {
                     json.add(key, childJson);
                 }
@@ -61,7 +61,7 @@ public class Json5Mapper {
                         json.add(key, Json5ArrayMapper.write(content));
                     } else if(StringUtil.isHexString(content)) {
                         json.add(key, Json5Primitive.of(content, true));
-                    } else if(NumberUtils.isCreatable(content)) {
+                    } else if(!isSaveAsStrings && NumberUtils.isCreatable(content)) {
                         json.add(key, Json5Primitive.of(NumberUtils.createNumber(content)));
                     } else {
                         json.add(key, Json5Primitive.of(StringEscapeUtils.unescapeJava(content)));

--- a/src/main/java/de/marhali/easyi18n/io/parser/json5/Json5ParserStrategy.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/json5/Json5ParserStrategy.java
@@ -27,9 +27,11 @@ public class Json5ParserStrategy extends ParserStrategy {
 
     private static final Json5 JSON5 = Json5.builder(builder ->
             builder.allowInvalidSurrogate().trailingComma().indentFactor(2).build());
+    private final boolean isSaveAsStrings;
 
     public Json5ParserStrategy(@NotNull ProjectSettings settings) {
         super(settings);
+        this.isSaveAsStrings = settings.isSaveAsStrings();
     }
 
     @Override
@@ -62,7 +64,7 @@ public class Json5ParserStrategy extends ParserStrategy {
         TranslationNode targetNode = super.getTargetNode(data, file);
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write(file.getLocale(), output, Objects.requireNonNull(targetNode));
+        Json5Mapper.write(file.getLocale(), output, Objects.requireNonNull(targetNode), isSaveAsStrings);
 
         return JSON5.serialize(output);
     }

--- a/src/main/java/de/marhali/easyi18n/io/parser/properties/PropertiesMapper.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/properties/PropertiesMapper.java
@@ -40,7 +40,7 @@ public class PropertiesMapper {
     }
 
     public static void write(String locale, SortableProperties properties,
-                             TranslationData data, KeyPathConverter converter) {
+                             TranslationData data, KeyPathConverter converter, boolean isSaveAsStrings) {
 
         for(KeyPath key : data.getFullKeys()) {
             TranslationValue translation = data.getTranslation(key);
@@ -51,7 +51,7 @@ public class PropertiesMapper {
 
                 if(PropertiesArrayMapper.isArray(content)) {
                     properties.put(simpleKey, PropertiesArrayMapper.write(content));
-                } else if(NumberUtils.isCreatable(content)) {
+                } else if(!isSaveAsStrings && NumberUtils.isCreatable(content)) {
                     properties.put(simpleKey, NumberUtils.createNumber(content));
                 } else {
                     properties.put(simpleKey, StringEscapeUtils.unescapeJava(content));

--- a/src/main/java/de/marhali/easyi18n/io/parser/properties/PropertiesParserStrategy.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/properties/PropertiesParserStrategy.java
@@ -24,10 +24,12 @@ import java.io.StringWriter;
 public class PropertiesParserStrategy extends ParserStrategy {
 
     private final @NotNull KeyPathConverter converter;
+    private final boolean isSaveAsStrings;
 
     public PropertiesParserStrategy(@NotNull ProjectSettings settings) {
         super(settings);
         this.converter = new KeyPathConverter(settings);
+        this.isSaveAsStrings = settings.isSaveAsStrings();
     }
 
     @Override
@@ -57,7 +59,7 @@ public class PropertiesParserStrategy extends ParserStrategy {
         TranslationData targetData = new TranslationData(data.getLocales(), targetNode);
 
         SortableProperties output = new SortableProperties(this.settings.isSorting());
-        PropertiesMapper.write(file.getLocale(), output, targetData, converter);
+        PropertiesMapper.write(file.getLocale(), output, targetData, converter, isSaveAsStrings);
 
         try(StringWriter writer = new StringWriter()) {
             output.store(writer);

--- a/src/main/java/de/marhali/easyi18n/io/parser/yaml/YamlMapper.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/yaml/YamlMapper.java
@@ -34,7 +34,7 @@ public class YamlMapper {
         }
     }
 
-    public static void write(String locale, Map<String, Object> section, TranslationNode node) {
+    public static void write(String locale, Map<String, Object> section, TranslationNode node, boolean isSaveAsStrings) {
         for(Map.Entry<String, TranslationNode> entry : node.getChildren().entrySet()) {
             String key = entry.getKey();
             TranslationNode childNode = entry.getValue();
@@ -42,7 +42,7 @@ public class YamlMapper {
             if(!childNode.isLeaf()) {
                 // Nested node - run recursively
                 Map<String, Object> childSection = new HashMap<>();
-                write(locale, childSection, childNode);
+                write(locale, childSection, childNode, isSaveAsStrings);
                 if(!childSection.isEmpty()) {
                     section.put(key, childSection);
                 }
@@ -53,7 +53,7 @@ public class YamlMapper {
                 if(content != null) {
                     if(YamlArrayMapper.isArray(content)) {
                         section.put(key, YamlArrayMapper.write(content));
-                    } else if(NumberUtils.isCreatable(content)) {
+                    } else if(!isSaveAsStrings && NumberUtils.isCreatable(content)) {
                         section.put(key, NumberUtils.createNumber(content));
                     } else {
                         section.put(key, StringEscapeUtils.unescapeJava(content));

--- a/src/main/java/de/marhali/easyi18n/io/parser/yaml/YamlParserStrategy.java
+++ b/src/main/java/de/marhali/easyi18n/io/parser/yaml/YamlParserStrategy.java
@@ -35,9 +35,11 @@ public class YamlParserStrategy extends ParserStrategy {
     }
 
     private static final Yaml YAML = new Yaml(dumperOptions());
+    private final boolean isSaveAsStrings;
 
     public YamlParserStrategy(@NotNull ProjectSettings settings) {
         super(settings);
+        this.isSaveAsStrings = settings.isSaveAsStrings();
     }
 
     @Override
@@ -65,7 +67,7 @@ public class YamlParserStrategy extends ParserStrategy {
         TranslationNode targetNode = super.getTargetNode(data, file);
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write(file.getLocale(), output, targetNode);
+        YamlMapper.write(file.getLocale(), output, targetNode, isSaveAsStrings);
 
         return YAML.dumpAsMap(output);
     }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
@@ -30,6 +30,8 @@ public interface ProjectSettings {
 
     boolean isSorting();
 
+    boolean isSaveAsStrings();
+
     // Editor Configuration
     @Nullable
     String getNamespaceDelimiter();

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
@@ -66,6 +66,7 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
                 .addVerticalGap(24)
                 .addComponent(new TitledSeparator(bundle.getString("settings.experimental.title")))
                 .addComponent(constructAlwaysFoldField())
+                .addComponent(constructSaveAsStringsField())
                 .addVerticalGap(12)
                 .addLabeledComponent(bundle.getString("settings.experimental.flavor-template"), constructFlavorTemplate(), 1, false)
                 .addLabeledComponent(bundle.getString("settings.experimental.key-naming-format.title"), constructKeyCaseFormater(), 1, false)
@@ -162,6 +163,12 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
         sorting = new JBCheckBox(bundle.getString("settings.resource.sorting.title"));
         sorting.setToolTipText(bundle.getString("settings.resource.sorting.tooltip"));
         return sorting;
+    }
+
+    private JComponent constructSaveAsStringsField() {
+        saveAsStrings = new JBCheckBox(bundle.getString("settings.experimental.saving-as-strings.title"));
+        saveAsStrings.setToolTipText(bundle.getString("settings.experimental.saving-as-strings.tooltip"));
+        return saveAsStrings;
     }
 
     private JPanel constructKeyStrategyPanel() {

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
@@ -27,6 +27,7 @@ public class ProjectSettingsComponentState {
 
     protected JCheckBox includeSubDirs;
     protected JCheckBox sorting;
+    protected JCheckBox saveAsStrings;
 
     // Editor configuration
     protected JTextField namespaceDelimiter;
@@ -56,6 +57,8 @@ public class ProjectSettingsComponentState {
 
         state.setIncludeSubDirs(includeSubDirs.isSelected());
         state.setSorting(sorting.isSelected());
+        state.setSaveAsStrings(saveAsStrings.isSelected());
+
 
         state.setNamespaceDelimiter(namespaceDelimiter.getText());
         state.setSectionDelimiter(sectionDelimiter.getText());
@@ -85,6 +88,7 @@ public class ProjectSettingsComponentState {
 
         includeSubDirs.setSelected(state.isIncludeSubDirs());
         sorting.setSelected(state.isSorting());
+        saveAsStrings.setSelected(state.isSaveAsStrings());
 
         namespaceDelimiter.setText(state.getNamespaceDelimiter());
         sectionDelimiter.setText(state.getSectionDelimiter());

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
@@ -33,6 +33,8 @@ public class ProjectSettingsState implements ProjectSettings {
     private Boolean includeSubDirs;
     @Property
     private boolean sorting;
+    @Property
+    private Boolean saveAsStrings;
 
     // Editor configuration
     @Property
@@ -83,6 +85,7 @@ public class ProjectSettingsState implements ProjectSettings {
 
         this.includeSubDirs = defaults.isIncludeSubDirs();
         this.sorting = defaults.isSorting();
+        this.saveAsStrings = defaults.isSaveAsStrings();
 
         this.namespaceDelimiter = defaults.getNamespaceDelimiter();
         this.sectionDelimiter = defaults.getSectionDelimiter();
@@ -128,6 +131,9 @@ public class ProjectSettingsState implements ProjectSettings {
     public boolean isSorting() {
         return sorting;
     }
+
+    @Override
+    public boolean isSaveAsStrings() { return saveAsStrings;}
 
     @Override
     public @Nullable String getNamespaceDelimiter() {
@@ -209,6 +215,10 @@ public class ProjectSettingsState implements ProjectSettings {
         this.sorting = sorting;
     }
 
+    public void setSaveAsStrings(Boolean saveAsStrings) {
+        this.saveAsStrings = saveAsStrings;
+    }
+
     public void setNamespaceDelimiter(String namespaceDelimiter) {
         this.namespaceDelimiter = namespaceDelimiter;
     }
@@ -260,6 +270,7 @@ public class ProjectSettingsState implements ProjectSettings {
         if (o == null || getClass() != o.getClass()) return false;
         ProjectSettingsState that = (ProjectSettingsState) o;
         return sorting == that.sorting
+                && saveAsStrings == that.saveAsStrings
                 && folderStrategy == that.folderStrategy
                 && parserStrategy == that.parserStrategy
                 && Objects.equals(localesDirectory, that.localesDirectory)
@@ -282,7 +293,7 @@ public class ProjectSettingsState implements ProjectSettings {
     public int hashCode() {
         return Objects.hash(
                 localesDirectory, folderStrategy, parserStrategy, filePattern, includeSubDirs,
-                sorting, namespaceDelimiter, sectionDelimiter, contextDelimiter, pluralDelimiter,
+                sorting, saveAsStrings, namespaceDelimiter, sectionDelimiter, contextDelimiter, pluralDelimiter,
                 defaultNamespace, previewLocale, nestedKeys, assistance, alwaysFold, flavorTemplate, caseFormat
         );
     }
@@ -296,6 +307,7 @@ public class ProjectSettingsState implements ProjectSettings {
                 ", filePattern='" + filePattern + '\'' +
                 ", includeSubDirs=" + includeSubDirs +
                 ", sorting=" + sorting +
+                ", saveAsStrings=" + saveAsStrings +
                 ", namespaceDelimiter='" + namespaceDelimiter + '\'' +
                 ", sectionDelimiter='" + sectionDelimiter + '\'' +
                 ", contextDelimiter='" + contextDelimiter + '\'' +

--- a/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
@@ -43,6 +43,9 @@ public class DefaultPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isSaveAsStrings() { return false; }
+
+    @Override
     public String getNamespaceDelimiter() {
         return ":";
     }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
@@ -43,6 +43,9 @@ public class ReactI18NextPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isSaveAsStrings() { return false; }
+
+    @Override
     public @Nullable String getNamespaceDelimiter() {
         return ":";
     }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
@@ -42,6 +42,9 @@ public class VueI18nPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isSaveAsStrings() { return false; }
+
+    @Override
     public @Nullable String getNamespaceDelimiter() {
         return null;
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -64,6 +64,8 @@ settings.experimental.flavor-template =I18n flavor template
 settings.experimental.flavor-template-tooltip = Specify how to replace strings with i18n representation.
 settings.experimental.key-naming-format.title=Key format of extracted translation
 settings.experimental.key-naming-format.tooltip=Choose Naming Convention for the keys of extracted translation
+settings.experimental.saving-as-strings.title=Save translations as strings.
+settings.experimental.saving-as-strings.tooltip=When enabled, all translation values will be saved as strings, without parsing numbers.
 
 error.io=An error occurred while processing translation files. \n\
   Config: {0} => {1} ({2}) \n\

--- a/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
+++ b/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
@@ -120,6 +120,11 @@ public class KeyPathConverterTest {
             }
 
             @Override
+            public boolean isSaveAsStrings() {
+                return false;
+            }
+
+            @Override
             public @Nullable String getNamespaceDelimiter() {
                 return namespaceDelim;
             }

--- a/src/test/java/de/marhali/easyi18n/mapper/AbstractMapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/AbstractMapperTest.java
@@ -39,6 +39,9 @@ public abstract class AbstractMapperTest {
     @Test
     public abstract void testNumbers();
 
+    @Test
+    public abstract void testNumbersAsStrings();
+
     protected TranslationValue create(String content) {
         return new TranslationValue("en", content);
     }

--- a/src/test/java/de/marhali/easyi18n/mapper/Json5MapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/Json5MapperTest.java
@@ -32,7 +32,7 @@ public class Json5MapperTest extends AbstractMapperTest {
         Json5Mapper.read("en", input, data.getRootNode());
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
         Set<String> expect = new LinkedHashSet<>(Arrays.asList("zulu", "alpha", "bravo"));
         Assert.assertEquals(expect, output.keySet());
@@ -49,7 +49,7 @@ public class Json5MapperTest extends AbstractMapperTest {
         Json5Mapper.read("en", input, data.getRootNode());
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
         Set<String> expect = new LinkedHashSet<>(Arrays.asList("alpha", "bravo", "zulu"));
         Assert.assertEquals(expect, output.keySet());
@@ -62,7 +62,7 @@ public class Json5MapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("escaped"), create(arrayEscaped));
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertTrue(output.get("simple").isJson5Array());
         Assert.assertEquals(arraySimple, Json5ArrayMapper.read(output.get("simple").getAsJson5Array()));
@@ -82,7 +82,7 @@ public class Json5MapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("chars"), create(specialCharacters));
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals(specialCharacters, output.get("chars").getAsString());
 
@@ -99,7 +99,7 @@ public class Json5MapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("nested", "key", "section"), create("test"));
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals("test", output.getAsJson5Object("nested").getAsJson5Object("key").get("section").getAsString());
 
@@ -115,7 +115,7 @@ public class Json5MapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("long.key.with.many.sections"), create("test"));
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertTrue(output.has("long.key.with.many.sections"));
 
@@ -131,7 +131,7 @@ public class Json5MapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("space"), create(leadingSpace));
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals(leadingSpace, output.get("space").getAsString());
 
@@ -144,12 +144,29 @@ public class Json5MapperTest extends AbstractMapperTest {
     @Override
     public void testNumbers() {
         TranslationData data = new TranslationData(true);
-        data.setTranslation(new KeyPath("numbered"), create("15000"));
+        data.setTranslation(new KeyPath("numbered"), create("+90d"));
 
         Json5Object output = new Json5Object();
-        Json5Mapper.write("en", output, data.getRootNode());
+        Json5Mapper.write("en", output, data.getRootNode(), false);
 
-        Assert.assertEquals(15000, output.get("numbered").getAsNumber());
+        Assert.assertEquals(90.0, output.get("numbered").getAsNumber());
+
+        Json5Object input = new Json5Object();
+        input.addProperty("numbered", 143.23);
+        Json5Mapper.read("en", input, data.getRootNode());
+
+        Assert.assertEquals("143.23", data.getTranslation(new KeyPath("numbered")).get("en"));
+    }
+
+    @Override
+    public void testNumbersAsStrings() {
+        TranslationData data = new TranslationData(true);
+        data.setTranslation(new KeyPath("stringNumbered"), create("+90d"));
+
+        Json5Object output = new Json5Object();
+        Json5Mapper.write("en", output, data.getRootNode(), true);
+
+        Assert.assertEquals("+90d", output.get("stringNumbered").getAsString());
 
         Json5Object input = new Json5Object();
         input.addProperty("numbered", 143.23);

--- a/src/test/java/de/marhali/easyi18n/mapper/JsonMapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/JsonMapperTest.java
@@ -33,7 +33,7 @@ public class JsonMapperTest extends AbstractMapperTest {
         JsonMapper.read("en", input, data.getRootNode());
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
         Set<String> expect = new LinkedHashSet<>(Arrays.asList("zulu", "alpha", "bravo"));
         Assert.assertEquals(expect, output.keySet());
@@ -50,7 +50,7 @@ public class JsonMapperTest extends AbstractMapperTest {
         JsonMapper.read("en", input, data.getRootNode());
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
         Set<String> expect = new LinkedHashSet<>(Arrays.asList("alpha", "bravo", "zulu"));
         Assert.assertEquals(expect, output.keySet());
@@ -63,7 +63,7 @@ public class JsonMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("escaped"), create(arrayEscaped));
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertTrue(output.get("simple").isJsonArray());
         Assert.assertEquals(arraySimple, JsonArrayMapper.read(output.get("simple").getAsJsonArray()));
@@ -83,7 +83,7 @@ public class JsonMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("chars"), create(specialCharacters));
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals(specialCharacters, output.get("chars").getAsString());
 
@@ -100,7 +100,7 @@ public class JsonMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("nested", "key", "section"), create("test"));
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals("test", output.getAsJsonObject("nested").getAsJsonObject("key").get("section").getAsString());
 
@@ -116,7 +116,7 @@ public class JsonMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("long.key.with.many.sections"), create("test"));
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertTrue(output.has("long.key.with.many.sections"));
 
@@ -132,7 +132,7 @@ public class JsonMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("space"), create(leadingSpace));
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals(leadingSpace, output.get("space").getAsString());
 
@@ -145,17 +145,35 @@ public class JsonMapperTest extends AbstractMapperTest {
     @Override
     public void testNumbers() {
         TranslationData data = new TranslationData(true);
-        data.setTranslation(new KeyPath("numbered"), create("15000"));
+        data.setTranslation(new KeyPath("numbered"), create("+90d"));
 
         JsonObject output = new JsonObject();
-        JsonMapper.write("en", output, data.getRootNode());
+        JsonMapper.write("en", output, data.getRootNode(), false);
 
-        Assert.assertEquals(15000, output.get("numbered").getAsNumber());
+        Assert.assertEquals(90.0, output.get("numbered").getAsNumber());
 
         JsonObject input = new JsonObject();
         input.addProperty("numbered", 143.23);
         JsonMapper.read("en", input, data.getRootNode());
 
         Assert.assertEquals("143.23", data.getTranslation(new KeyPath("numbered")).get("en"));
+    }
+
+    @Override
+    public void testNumbersAsStrings() {
+        TranslationData data = new TranslationData(true);
+        data.setTranslation(new KeyPath("stringNumbered"), create("+90d"));
+
+        JsonObject output = new JsonObject();
+        JsonMapper.write("en", output, data.getRootNode(), true);
+
+        Assert.assertEquals("+90d", output.get("stringNumbered").getAsString());
+
+        JsonObject input = new JsonObject();
+        input.addProperty("numbered", 143.23);
+        JsonMapper.read("en", input, data.getRootNode());
+
+        Assert.assertEquals("143.23", data.getTranslation(new KeyPath("numbered")).get("en"));
+
     }
 }

--- a/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
@@ -36,7 +36,7 @@ public class PropertiesMapperTest extends AbstractMapperTest {
         PropertiesMapper.read("en", input, data, converter(true));
 
         SortableProperties output = new SortableProperties(false);
-        PropertiesMapper.write("en", output, data, converter(true));
+        PropertiesMapper.write("en", output, data, converter(true), false);
 
         List<String> expect = Arrays.asList("zulu", "alpha", "bravo");
         Assert.assertEquals(expect, new ArrayList<>(output.keySet()));
@@ -53,7 +53,7 @@ public class PropertiesMapperTest extends AbstractMapperTest {
         PropertiesMapper.read("en", input, data, converter(true));
 
         SortableProperties output = new SortableProperties(true);
-        PropertiesMapper.write("en", output, data, converter(true));
+        PropertiesMapper.write("en", output, data, converter(true), false);
 
         List<String> expect = Arrays.asList("alpha", "bravo", "zulu");
         Assert.assertEquals(expect, new ArrayList<>(output.keySet()));
@@ -66,7 +66,7 @@ public class PropertiesMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("escaped"), create(arrayEscaped));
 
         SortableProperties output = new SortableProperties(true);
-        PropertiesMapper.write("en", output, data, converter(true));
+        PropertiesMapper.write("en", output, data, converter(true), false);
 
         Assert.assertTrue(output.get("simple") instanceof String[]);
         Assert.assertEquals(arraySimple, PropertiesArrayMapper.read((String[]) output.get("simple")));
@@ -86,7 +86,7 @@ public class PropertiesMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("chars"), create(specialCharacters));
 
         SortableProperties output = new SortableProperties(true);
-        PropertiesMapper.write("en", output, data, converter(true));
+        PropertiesMapper.write("en", output, data, converter(true), false);
 
         Assert.assertEquals(specialCharacters, output.get("chars"));
 
@@ -102,7 +102,7 @@ public class PropertiesMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("nested", "key", "sections"), create("test"));
 
         SortableProperties output = new SortableProperties(true);
-        PropertiesMapper.write("en", output, data, converter(true));
+        PropertiesMapper.write("en", output, data, converter(true), false);
 
         Assert.assertEquals("test", output.get("nested:key.sections"));
 
@@ -119,7 +119,7 @@ public class PropertiesMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("long.key.with.many.sections"), create("test"));
 
         SortableProperties output = new SortableProperties(true);
-        PropertiesMapper.write("en", output, data, converter(false));
+        PropertiesMapper.write("en", output, data, converter(false), false);
 
         Assert.assertNotNull(output.get("long.key.with.many.sections"));
 
@@ -135,7 +135,7 @@ public class PropertiesMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("space"), create(leadingSpace));
 
         SortableProperties output = new SortableProperties(true);
-        PropertiesMapper.write("en", output, data, converter());
+        PropertiesMapper.write("en", output, data, converter(), false);
 
         Assert.assertEquals(leadingSpace, output.get("space"));
 
@@ -148,18 +148,36 @@ public class PropertiesMapperTest extends AbstractMapperTest {
     @Override
     public void testNumbers() {
         TranslationData data = new TranslationData(true);
-        data.setTranslation(new KeyPath("numbered"), create("15000"));
+        data.setTranslation(new KeyPath("numbered"), create("+90d"));
 
         SortableProperties output = new SortableProperties(true);
-        PropertiesMapper.write("en", output, data, converter());
+        PropertiesMapper.write("en", output, data, converter(), false);
 
-        Assert.assertEquals(15000, output.get("numbered"));
+        Assert.assertEquals(90.0, output.get("numbered"));
 
         SortableProperties input = new SortableProperties(true);
         input.put("numbered", 143.23);
         PropertiesMapper.read("en", input, data, converter());
 
         Assert.assertEquals("143.23", data.getTranslation(new KeyPath("numbered")).get("en"));
+    }
+
+    @Override
+    public void testNumbersAsStrings() {
+        TranslationData data = new TranslationData(true);
+        data.setTranslation(new KeyPath("stringNumbered"), create("+90d"));
+
+        SortableProperties output = new SortableProperties(true);
+        PropertiesMapper.write("en", output, data, converter(), true);
+
+        Assert.assertEquals("+90d", output.get("stringNumbered"));
+
+        SortableProperties input = new SortableProperties(true);
+        input.put("numbered", 143.23);
+        PropertiesMapper.read("en", input, data, converter());
+
+        Assert.assertEquals("143.23", data.getTranslation(new KeyPath("numbered")).get("en"));
+
     }
 
     private KeyPathConverter converter() {
@@ -190,6 +208,11 @@ public class PropertiesMapperTest extends AbstractMapperTest {
 
             @Override
             public boolean isSorting() {
+                return true;
+            }
+
+            @Override
+            public boolean isSaveAsStrings() {
                 return true;
             }
 

--- a/src/test/java/de/marhali/easyi18n/mapper/YamlMapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/YamlMapperTest.java
@@ -28,7 +28,7 @@ public class YamlMapperTest extends AbstractMapperTest {
         YamlMapper.read("en", input, data.getRootNode());
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), true);
 
         Set<String> expect = new LinkedHashSet<>(Arrays.asList("zulu", "alpha", "bravo"));
         Assert.assertEquals(expect, output.keySet());
@@ -45,7 +45,7 @@ public class YamlMapperTest extends AbstractMapperTest {
         YamlMapper.read("en", input, data.getRootNode());
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), false);
 
         Set<String> expect = new LinkedHashSet<>(Arrays.asList("alpha", "bravo", "zulu"));
         Assert.assertEquals(expect, output.keySet());
@@ -58,7 +58,7 @@ public class YamlMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("escaped"), create(arrayEscaped));
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertTrue(output.get("simple") instanceof List);
         Assert.assertEquals(arraySimple, YamlArrayMapper.read((List<Object>) output.get("simple")));
@@ -78,7 +78,7 @@ public class YamlMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("chars"), create(specialCharacters));
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals(specialCharacters, output.get("chars"));
 
@@ -95,7 +95,7 @@ public class YamlMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("nested", "key", "section"), create("test"));
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertTrue(output.containsKey("nested"));
         Assert.assertTrue(((Map<String, Object>) output.get("nested")).containsKey("key"));
@@ -114,7 +114,7 @@ public class YamlMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("long.key.with.many.sections"), create("test"));
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertTrue(output.containsKey("long.key.with.many.sections"));
 
@@ -130,7 +130,7 @@ public class YamlMapperTest extends AbstractMapperTest {
         data.setTranslation(new KeyPath("space"), create(leadingSpace));
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), false);
 
         Assert.assertEquals(leadingSpace, output.get("space"));
 
@@ -143,12 +143,29 @@ public class YamlMapperTest extends AbstractMapperTest {
     @Override
     public void testNumbers() {
         TranslationData data = new TranslationData(true);
-        data.setTranslation(new KeyPath("numbered"), create("15000"));
+        data.setTranslation(new KeyPath("numbered"), create("+90d"));
 
         Map<String, Object> output = new HashMap<>();
-        YamlMapper.write("en", output, data.getRootNode());
+        YamlMapper.write("en", output, data.getRootNode(), false);
 
-        Assert.assertEquals(15000, output.get("numbered"));
+        Assert.assertEquals(90.0, output.get("numbered"));
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("numbered", 143.23);
+        YamlMapper.read("en", input, data.getRootNode());
+
+        Assert.assertEquals("143.23", data.getTranslation(new KeyPath("numbered")).get("en"));
+    }
+
+    @Override
+    public void testNumbersAsStrings() {
+        TranslationData data = new TranslationData(true);
+        data.setTranslation(new KeyPath("stringNumbered"), create("+90d"));
+
+        Map<String, Object> output = new HashMap<>();
+        YamlMapper.write("en", output, data.getRootNode(), true);
+
+        Assert.assertEquals("+90d", output.get("stringNumbered"));
 
         Map<String, Object> input = new HashMap<>();
         input.put("numbered", 143.23);

--- a/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
+++ b/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
@@ -44,6 +44,11 @@ public class SettingsTestPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isSaveAsStrings() {
+        return false;
+    }
+
+    @Override
     public @Nullable String getNamespaceDelimiter() {
         return "nsDelim";
     }


### PR DESCRIPTION
In this pull request I created a new setting allowing to save the numbers as strings without parsing them:

![Screenshot 2025-05-09 183848](https://github.com/user-attachments/assets/4ca91a24-0a10-40c2-8c48-1df1557029e4)


This allows to have specific translations that are not numbers to stay strings:

Examples with the setting activated:
![image](https://github.com/user-attachments/assets/fe0121d9-db37-4d94-9c32-15d20afca30a)


And disabled:
![image](https://github.com/user-attachments/assets/3b38df0a-eb4d-4edb-a1b5-0ba7d3e79d32)
