### PR TITLE
implement setting to have a blank line at the end of translation files

### DIFF
--- a/src/main/java/de/marhali/easyi18n/io/IOHandler.java
+++ b/src/main/java/de/marhali/easyi18n/io/IOHandler.java
@@ -95,6 +95,7 @@ public class IOHandler {
      */
     public void write(@NotNull TranslationData data) throws IOException {
         String localesPath = this.settings.getLocalesDirectory();
+        boolean isAddBlankLine = this.settings.isAddBlankLine();
 
         if(localesPath == null || localesPath.isEmpty()) {
             throw new EmptyLocalesDirException("Locales path must not be empty");
@@ -110,6 +111,10 @@ public class IOHandler {
                 if(content == null) {
                     // We should consider deleting the target translation file if it has no content
                     continue;
+                }
+
+                if (isAddBlankLine && !content.endsWith("\n")) {
+                    content += "\n";
                 }
 
                 Document document = FileDocumentManager.getInstance().getDocument(file.getVirtualFile());

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettings.java
@@ -56,6 +56,8 @@ public interface ProjectSettings {
     // Experimental Configuration
     boolean isAlwaysFold();
 
+    boolean isAddBlankLine();
+
     String getFlavorTemplate();
 
     @NotNull

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponent.java
@@ -66,6 +66,7 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
                 .addVerticalGap(24)
                 .addComponent(new TitledSeparator(bundle.getString("settings.experimental.title")))
                 .addComponent(constructAlwaysFoldField())
+                .addComponent(constructIsAddBlankLineField())
                 .addVerticalGap(12)
                 .addLabeledComponent(bundle.getString("settings.experimental.flavor-template"), constructFlavorTemplate(), 1, false)
                 .addLabeledComponent(bundle.getString("settings.experimental.key-naming-format.title"), constructKeyCaseFormater(), 1, false)
@@ -235,6 +236,12 @@ public class ProjectSettingsComponent extends ProjectSettingsComponentState {
         KeyCaseFormater.setToolTipText(bundle.getString("settings.experimental.key-naming-format.tooltip"));
         KeyCaseFormater.setMinimumAndPreferredWidth(200);
         return KeyCaseFormater;
+    }
+
+    private JComponent constructIsAddBlankLineField() {
+        addBlankLine = new JBCheckBox(bundle.getString("settings.experimental.add-blank-line.title"));
+        addBlankLine.setToolTipText(bundle.getString("settings.experimental.add-blank-line.tooltip"));
+        return addBlankLine;
     }
 
 

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsComponentState.java
@@ -27,6 +27,7 @@ public class ProjectSettingsComponentState {
 
     protected JCheckBox includeSubDirs;
     protected JCheckBox sorting;
+    protected JCheckBox addBlankLine;
 
     // Editor configuration
     protected JTextField namespaceDelimiter;
@@ -68,6 +69,7 @@ public class ProjectSettingsComponentState {
         state.setAssistance(assistance.isSelected());
 
         state.setAlwaysFold(alwaysFold.isSelected());
+        state.setAddBlankLine(addBlankLine.isSelected());
 
         state.setFlavorTemplate(flavorTemplate.getText());
 
@@ -97,6 +99,7 @@ public class ProjectSettingsComponentState {
         assistance.setSelected(state.isAssistance());
 
         alwaysFold.setSelected(state.isAlwaysFold());
+        addBlankLine.setSelected(state.isAddBlankLine());
         flavorTemplate.setText(state.getFlavorTemplate());
         KeyCaseFormater.setSelectedItem(state.getCaseFormat().getName());
     }

--- a/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
+++ b/src/main/java/de/marhali/easyi18n/settings/ProjectSettingsState.java
@@ -56,6 +56,8 @@ public class ProjectSettingsState implements ProjectSettings {
     // Experimental configuration
     @Property
     private Boolean alwaysFold;
+    @Property
+    private Boolean addBlankLine;
 
     /**
      * The `flavorTemplate` specifies the format used for replacing strings with their i18n (internationalization) counterparts.
@@ -95,6 +97,7 @@ public class ProjectSettingsState implements ProjectSettings {
         this.assistance = defaults.isAssistance();
 
         this.alwaysFold = defaults.isAlwaysFold();
+        this.addBlankLine = defaults.isAddBlankLine();
         this.flavorTemplate = defaults.getFlavorTemplate();
         this.caseFormat = defaults.getCaseFormat();
     }
@@ -176,6 +179,9 @@ public class ProjectSettingsState implements ProjectSettings {
     }
 
     @Override
+    public boolean isAddBlankLine() { return addBlankLine;}
+
+    @Override
     public String getFlavorTemplate() {
         return this.flavorTemplate;
     }
@@ -245,6 +251,8 @@ public class ProjectSettingsState implements ProjectSettings {
         this.alwaysFold = alwaysFold;
     }
 
+    public void setAddBlankLine(Boolean addBlankLine) { this.addBlankLine = addBlankLine; }
+
     public void setFlavorTemplate(String flavorTemplate) {
         this.flavorTemplate = flavorTemplate;
     }
@@ -262,6 +270,7 @@ public class ProjectSettingsState implements ProjectSettings {
         return sorting == that.sorting
                 && folderStrategy == that.folderStrategy
                 && parserStrategy == that.parserStrategy
+                && addBlankLine == that.addBlankLine
                 && Objects.equals(localesDirectory, that.localesDirectory)
                 && Objects.equals(filePattern, that.filePattern)
                 && Objects.equals(includeSubDirs, that.includeSubDirs)
@@ -283,7 +292,7 @@ public class ProjectSettingsState implements ProjectSettings {
         return Objects.hash(
                 localesDirectory, folderStrategy, parserStrategy, filePattern, includeSubDirs,
                 sorting, namespaceDelimiter, sectionDelimiter, contextDelimiter, pluralDelimiter,
-                defaultNamespace, previewLocale, nestedKeys, assistance, alwaysFold, flavorTemplate, caseFormat
+                defaultNamespace, previewLocale, nestedKeys, assistance, alwaysFold, addBlankLine, flavorTemplate, caseFormat
         );
     }
 
@@ -305,6 +314,7 @@ public class ProjectSettingsState implements ProjectSettings {
                 ", nestedKeys=" + nestedKeys +
                 ", assistance=" + assistance +
                 ", alwaysFold=" + alwaysFold +
+                ", addBlankLine=" + addBlankLine +
                 ", flavorTemplate=" + flavorTemplate +
                 ", caseFormat=" + caseFormat.toString() +
                 '}';

--- a/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/DefaultPreset.java
@@ -88,6 +88,9 @@ public class DefaultPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isAddBlankLine() {return false; }
+
+    @Override
     public String getFlavorTemplate() {
         return "$i18n.t";
     }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/ReactI18NextPreset.java
@@ -88,6 +88,9 @@ public class ReactI18NextPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isAddBlankLine() {return false; }
+
+    @Override
     public String getFlavorTemplate() {
         return "$i18n.t";
     }

--- a/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
+++ b/src/main/java/de/marhali/easyi18n/settings/presets/VueI18nPreset.java
@@ -87,6 +87,9 @@ public class VueI18nPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isAddBlankLine() {return false; }
+
+    @Override
     public String getFlavorTemplate() {
         return "$i18n.t";
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -64,6 +64,9 @@ settings.experimental.flavor-template =I18n flavor template
 settings.experimental.flavor-template-tooltip = Specify how to replace strings with i18n representation.
 settings.experimental.key-naming-format.title=Key format of extracted translation
 settings.experimental.key-naming-format.tooltip=Choose Naming Convention for the keys of extracted translation
+settings.experimental.add-blank-line.title=Add blank line at the enf of the files
+settings.experimental.add-blank-line.tooltip=When enabled, this setting will add a blank line at the end of the translation file.
+
 
 error.io=An error occurred while processing translation files. \n\
   Config: {0} => {1} ({2}) \n\

--- a/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
+++ b/src/test/java/de/marhali/easyi18n/KeyPathConverterTest.java
@@ -165,6 +165,9 @@ public class KeyPathConverterTest {
             }
 
             @Override
+            public boolean isAddBlankLine() { return false; }
+
+            @Override
             public String getFlavorTemplate() {
                 return "";
             }

--- a/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
+++ b/src/test/java/de/marhali/easyi18n/mapper/PropertiesMapperTest.java
@@ -239,6 +239,9 @@ public class PropertiesMapperTest extends AbstractMapperTest {
             }
 
             @Override
+            public boolean isAddBlankLine() { return false; }
+
+            @Override
             public String getFlavorTemplate() {
                 return "";
             }

--- a/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
+++ b/src/test/java/de/marhali/easyi18n/settings/SettingsTestPreset.java
@@ -89,6 +89,9 @@ public class SettingsTestPreset implements ProjectSettings {
     }
 
     @Override
+    public boolean isAddBlankLine() { return false; }
+
+    @Override
     public String getFlavorTemplate() {
         return "t";
     }


### PR DESCRIPTION
This feature Add a setting to have a blank line at the end of the files:

![image](https://github.com/user-attachments/assets/9c92ab32-0658-4f05-bd73-a009079d33fa)
![image](https://github.com/user-attachments/assets/f6c6bc3d-340a-4a95-858d-774556700678)


with the option enabled:
![image](https://github.com/user-attachments/assets/43920020-b9ed-4088-8599-e49ab6758279)


I needed this feature and also solve other issues in the project.
https://github.com/marhali/easy-i18n/issues/448

I could use some help/ guides to implement the tests on this feature if needed