### PR TITLE
Fix slow VFS read on EDT when loading translations (#516, #509)

### DIFF
--- a/src/main/java/de/marhali/easyi18n/DataStore.java
+++ b/src/main/java/de/marhali/easyi18n/DataStore.java
@@ -66,6 +66,7 @@ public class DataStore {
                         return new TranslationData(settings.isSorting());
                     }
                 })
+                .expireWith(project)
                 .finishOnUiThread(ModalityState.defaultInstance(), loadedData -> {
                     this.data = loadedData;
 


### PR DESCRIPTION
This PR fixes an IDE error caused by performing slow VFS I/O on the Event Dispatch Thread (EDT) when loading translation files.

Fixes #516  
Fixes #509